### PR TITLE
Preserve error context when loading Cognito credentials

### DIFF
--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -1169,7 +1169,7 @@ export default class AuthClass {
                 },
                 (err) => {
                     logger.debug('Failed to load credentials', credentials);
-                    rej('Failed to load creadentials');
+                    rej(err);
                 }
             );
         });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When the Amplify `AuthClass` class fetches credentials using `AWS.CognitoIdentityCredentials` and an error occurs, the original error is lost in the callback chain, making it difficult to debug what went wrong. This change rejects the Promise will the original error.

I've tried to run the tests to check that this doesn't cause any failures, but they fail on my fresh master checkout at the `eslint` stage. Is this a know issue?

Secondly, given that `_loadCredentials` is a private method, can you suggest an appropriate place to add some tests for this change?

Thanks!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
